### PR TITLE
Increment dimension member index

### DIFF
--- a/lib/AWS/Cloudwatch/monitoring.rb
+++ b/lib/AWS/Cloudwatch/monitoring.rb
@@ -159,6 +159,8 @@ module AWS
               dimension_prefix + "Name" => dimension,
               dimension_prefix + "Value" => value
             })
+            
+            ii += 1
           end unless datum[:dimensions].nil?
 
           params.merge! datum_params


### PR DESCRIPTION
Because the ii variable is never incremented multiple dimensions simply override each other and as a result you cannot pass more than one dimension.
